### PR TITLE
Automatically focus the input field on search page

### DIFF
--- a/qml/pages/SearchPage.qml
+++ b/qml/pages/SearchPage.qml
@@ -34,6 +34,7 @@ Page {
             width: parent.width
             focus: true
             onTextChanged: model.filter = text
+            Component.onCompleted: { forceActiveFocus(); }
         }
 
         delegate: PasswordDelegate {


### PR DESCRIPTION
Hi,

Before this change I needed to tap on the input field at the very top of the screen and go back to the keyboard at the very bottom of the screen. I think this makes the UX a little bit smoother.