### PR TITLE
Don’t use pinentry-mode option when using gpg2 version < 2.1

### DIFF
--- a/src/gpg.cpp
+++ b/src/gpg.cpp
@@ -217,17 +217,24 @@ void Gpg::DecryptTask::run()
     const auto gpg = findGpgExecutable();
     QProcess process;
     process.setProgram(gpg.path);
-    process.setArguments({QStringLiteral("--quiet"),
-                          QStringLiteral("--batch"),
-                          QStringLiteral("--decrypt"),
-                          QStringLiteral("--no-tty"),
-                          QStringLiteral("--command-fd=1"),
-                          QStringLiteral("--no-encrypt-to"),
-                          QStringLiteral("--compress-algo=none"),
-                          QStringLiteral("--passphrase-fd=0"),
-                          QStringLiteral("--pinentry-mode=loopback"),
-                          QStringLiteral("-r %1").arg(mKey.id),
-                          mFile});
+    QStringList arguments{
+        QStringLiteral("--quiet"),
+        QStringLiteral("--batch"),
+        QStringLiteral("--decrypt"),
+        QStringLiteral("--no-tty"),
+        QStringLiteral("--command-fd=1"),
+        QStringLiteral("--no-encrypt-to"),
+        QStringLiteral("--compress-algo=none"),
+        QStringLiteral("--passphrase-fd=0")
+    };
+
+    if (gpg.minor_version >= 1) {
+        arguments << QStringLiteral("--pinentry-mode=loopback");
+    }
+
+    arguments << QStringLiteral ("-r %1").arg (mKey.id) << mFile;
+
+    process.setArguments(arguments);
     process.start();
     process.waitForStarted();
     process.write(mPassphrase.toUtf8());


### PR DESCRIPTION
Hi,

Up until 0.4 you used to test for gpg version before building the list of arguments to it but you removed it for version 0.5.
Unfortunately, gpg2 version provided by jolla is still 2.0.4 and doesn't provide --pinentry-mode option.

This patch just reverts the test.

Thanks, 